### PR TITLE
showcase items take up width based on screen orientation

### DIFF
--- a/assets/scss/showcase.scss
+++ b/assets/scss/showcase.scss
@@ -5,8 +5,20 @@
 
 .showcase-item {
   padding: 1em;
-  width: 25em;
 }
+
+@media screen and (orientation:portrait) {
+  .showcase-item {
+    width: 90%;
+  }
+}
+/* Landscape */
+@media screen and (orientation:landscape) {
+  .showcase-item {
+    width: 30%;
+  }
+}
+
 
 .showcase-image {
   height: 20vh;


### PR DESCRIPTION
portrait devices, such as mobiles get one item per line
landscape devices such as desktop get 3

hopefully