### PR TITLE
Adds Publishing Checks

### DIFF
--- a/.github/workflows/publish-check.yml
+++ b/.github/workflows/publish-check.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Check that the post has been set to publish
         run: |
           for file_path in $(git diff --name-only origin/main | grep '^content/'); do
-            grep --regexp='^draft\:\w+true$' "$file_path";
+            grep --regexp='^draft\:\w+false$' "$file_path";
           done
       - name: Check that the date is today or later
         run: |


### PR DESCRIPTION
Checks if a post that is intending to be published is configured correctly

Checks:
* That the publish date is the day the PR was created or later
* That the draft setting is not true